### PR TITLE
DOC: Updated RSL links and NOAA data links.

### DIFF
--- a/content/pages/opendata.md
+++ b/content/pages/opendata.md
@@ -10,7 +10,7 @@ Title: List of open weather radar data repositories
 
 
 ### National Oceanic and Atmospheric Administration (NOAA)
-<https://www.ncdc.noaa.gov/data-access/radar-data>
+<https://registry.opendata.aws/noaa-nexrad/>
 
 
 ### Royal Netherlands Meteorological Institute (KNMI)

--- a/content/posts/rsl.md
+++ b/content/posts/rsl.md
@@ -7,10 +7,7 @@ Tags: project, devel, c
 ---
 
 ## Quick description
-NASA's Radar Software Library (RSL) was developed to support the Tropical
-Rainfall Measuring Mission (TRMM). It is designed to read data from a variety
-of weather radar formats into a uniform structure, and provide tools for
-working with the data. It is written in the C language.
+NASA's Radar Software Library (RSL) was developed to support the Tropical Rainfall Measuring Mission (TRMM). It is designed to read data from a variety of weather radar formats into a uniform structure, and provide tools for working with the data. It is written in the C language.
 
 ## Homepage
 <https://trmm-fc.gsfc.nasa.gov/trmm_gv/software/rsl/>

--- a/content/posts/rsl.md
+++ b/content/posts/rsl.md
@@ -7,16 +7,19 @@ Tags: project, devel, c
 ---
 
 ## Quick description
-NASA's Radar Software Library (RSL) was developed to support the Tropical Rainfall Measuring Mission (TRMM).  It is designed to read data from a variety of weather radar formats into a uniform structure, and provide tools for working with the data.  It is written in the C language.
+NASA's Radar Software Library (RSL) was developed to support the Tropical
+Rainfall Measuring Mission (TRMM). It is designed to read data from a variety
+of weather radar formats into a uniform structure, and provide tools for
+working with the data. It is written in the C language.
 
 ## Homepage
-<http://trmm-fc.gsfc.nasa.gov/trmm_gv/software/rsl/index.html>
+<https://trmm-fc.gsfc.nasa.gov/trmm_gv/software/rsl/>
 
 ## Code Repository
 N/A
 
 ## Software Documentation
-<http://trmm-fc.gsfc.nasa.gov/trmm_gv/software/rsl/index.html>
+<https://trmm-fc.gsfc.nasa.gov/trmm_gv/software/rsl/quick_ref.php>
 
 ## User group or forum page
 N/A

--- a/content/posts/rsl_in_idl.md
+++ b/content/posts/rsl_in_idl.md
@@ -10,13 +10,13 @@ Tags: project, devel, idl
 RSL in IDL is a package of routines for working with TRMM Ground Validation radar data. The programs and data structures are modeled on TRMM GV's C-based Radar Software Library (RSL), but are written in the Interactive Data Language (IDL). The idea is to provide the utility of RSL in an IDL environment.
 
 ## Homepage
-<http://trmm-fc/trmm_gv/software/rsl_in_idl/RSL_in_IDL.html>
+<https://trmm-fc.gsfc.nasa.gov/trmm_gv/software/rsl_in_idl/RSL_in_IDL.php>
 
 ## Code Repository
 N/A
 
 ## Software Documentation
-<http://trmm-fc/trmm_gv/software/rsl_in_idl/RSL_in_IDL.html>
+<https://trmm-fc.gsfc.nasa.gov/trmm_gv/software/rsl_in_idl/rsl_routines.php>
 
 ## User group or forum page
 N/A


### PR DESCRIPTION
Links for rsl changed on nasa's website. Noticed noaa data link was broken, I believe due to their nexrad data being moved to AWS.